### PR TITLE
ServeStatic logic refactoring

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "files.associations": {
+        "__config": "cpp",
+        "fstream": "cpp",
+        "locale": "cpp"
+    }
+}

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
@@ -619,17 +619,31 @@ void ESP8266WebServerTemplate<ServerType>::collectHeaders(const char* headerKeys
   }
 }
 
+// template<typename ServerType>
+// void ESP8266WebServerETagTemplate<ServerType>::collectHeaders(const char* headerKeys[], const size_t headerKeysCount) {
+//   WST::_headerKeysCount = headerKeysCount + 2;
+//   if (WST::_currentHeaders){
+//     delete[] WST::_currentHeaders;
+//   }
+//   WST::_currentHeaders = new typename WST::RequestArgument[WST::_headerKeysCount];
+//   WST::_currentHeaders[0].key = FPSTR(AUTHORIZATION_HEADER);
+//   WST::_currentHeaders[1].key = FPSTR(ETAG_HEADER);
+//   for (int i = 2; i < WST::_headerKeysCount; i++){
+//       WST::_currentHeaders[i].key = headerKeys[i-2];
+//   }
+// }
+
 template<typename ServerType>
 void ESP8266WebServerETagTemplate<ServerType>::collectHeaders(const char* headerKeys[], const size_t headerKeysCount) {
-  WST::_headerKeysCount = headerKeysCount + 2;
-  if (WST::_currentHeaders){
-    delete[] WST::_currentHeaders;
+  _headerKeysCount = headerKeysCount + 2;
+  if (_currentHeaders){
+    delete[] _currentHeaders;
   }
-  WST::_currentHeaders = new typename WST::RequestArgument[WST::_headerKeysCount];
-  WST::_currentHeaders[0].key = FPSTR(AUTHORIZATION_HEADER);
-  WST::_currentHeaders[1].key = FPSTR(ETAG_HEADER);
-  for (int i = 2; i < WST::_headerKeysCount; i++){
-      WST::_currentHeaders[i].key = headerKeys[i-2];
+  _currentHeaders = new typename RequestArgument[_headerKeysCount];
+  _currentHeaders[0].key = FPSTR(AUTHORIZATION_HEADER);
+  _currentHeaders[1].key = FPSTR(ETAG_HEADER);
+  for (int i = 2; i < _headerKeysCount; i++){
+      _currentHeaders[i].key = headerKeys[i-2];
   }
 }
 
@@ -846,10 +860,16 @@ String ESP8266WebServerTemplate<ServerType>::responseCodeToString(const int code
     return String(r);
 }
 
+// template<typename ServerType>
+// void ESP8266WebServerETagTemplate<ServerType>::serveStaticETag(const char* uri, FS& fs, const char* path, const char* cache_header){
+//   WST::_addRequestHandler(new StaticRequestETagHandler<ServerType>(fs, path, uri, cache_header));
+// }
+
 template<typename ServerType>
 void ESP8266WebServerETagTemplate<ServerType>::serveStaticETag(const char* uri, FS& fs, const char* path, const char* cache_header){
-  WST::_addRequestHandler(new StaticRequestETagHandler<ServerType>(fs, path, uri, cache_header));
+  _addRequestHandler(new StaticRequestETagHandler<ServerType>(fs, path, uri, cache_header));
 }
+
 
 template<typename ServerType>
 void ESP8266WebServerETagTemplate<ServerType>::serveStaticETag(const char* uri, FS& fs, const char * path) {

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
@@ -619,31 +619,17 @@ void ESP8266WebServerTemplate<ServerType>::collectHeaders(const char* headerKeys
   }
 }
 
-// template<typename ServerType>
-// void ESP8266WebServerETagTemplate<ServerType>::collectHeaders(const char* headerKeys[], const size_t headerKeysCount) {
-//   WST::_headerKeysCount = headerKeysCount + 2;
-//   if (WST::_currentHeaders){
-//     delete[] WST::_currentHeaders;
-//   }
-//   WST::_currentHeaders = new typename WST::RequestArgument[WST::_headerKeysCount];
-//   WST::_currentHeaders[0].key = FPSTR(AUTHORIZATION_HEADER);
-//   WST::_currentHeaders[1].key = FPSTR(ETAG_HEADER);
-//   for (int i = 2; i < WST::_headerKeysCount; i++){
-//       WST::_currentHeaders[i].key = headerKeys[i-2];
-//   }
-// }
-
 template<typename ServerType>
 void ESP8266WebServerETagTemplate<ServerType>::collectHeaders(const char* headerKeys[], const size_t headerKeysCount) {
-  _headerKeysCount = headerKeysCount + 2;
-  if (_currentHeaders){
-    delete[] _currentHeaders;
+  WST::_headerKeysCount = headerKeysCount + 2;
+  if (WST::_currentHeaders){
+    delete[] WST::_currentHeaders;
   }
-  _currentHeaders = new typename RequestArgument[_headerKeysCount];
-  _currentHeaders[0].key = FPSTR(AUTHORIZATION_HEADER);
-  _currentHeaders[1].key = FPSTR(ETAG_HEADER);
-  for (int i = 2; i < _headerKeysCount; i++){
-      _currentHeaders[i].key = headerKeys[i-2];
+  WST::_currentHeaders = new typename WST::RequestArgument[WST::_headerKeysCount];
+  WST::_currentHeaders[0].key = FPSTR(AUTHORIZATION_HEADER);
+  WST::_currentHeaders[1].key = FPSTR(ETAG_HEADER);
+  for (int i = 2; i < WST::_headerKeysCount; i++){
+      WST::_currentHeaders[i].key = headerKeys[i-2];
   }
 }
 
@@ -860,43 +846,16 @@ String ESP8266WebServerTemplate<ServerType>::responseCodeToString(const int code
     return String(r);
 }
 
+template<typename ServerType>
+void ESP8266WebServerETagTemplate<ServerType>::serveStatic(const char* uri, FS& fs, const char* path, const char* cache_header){
+  WST::_addRequestHandler(new StaticRequestETagHandler<ServerType>(fs, path, uri, cache_header));
+}
+
+
 // template<typename ServerType>
-// void ESP8266WebServerETagTemplate<ServerType>::serveStaticETag(const char* uri, FS& fs, const char* path, const char* cache_header){
-//   WST::_addRequestHandler(new StaticRequestETagHandler<ServerType>(fs, path, uri, cache_header));
-// }
-
-template<typename ServerType>
-void ESP8266WebServerETagTemplate<ServerType>::serveStaticETag(const char* uri, FS& fs, const char* path, const char* cache_header){
-  _addRequestHandler(new StaticRequestETagHandler<ServerType>(fs, path, uri, cache_header));
-}
-
-
-template<typename ServerType>
-void ESP8266WebServerETagTemplate<ServerType>::serveStaticETag(const char* uri, FS& fs, const char * path) {
-
-  File toHash = fs.open(path, "r");
-
-  if(toHash){
-
-    MD5Builder calcMD5;
-    calcMD5.begin();
-
-    calcMD5.addStream(toHash, toHash.size());
-
-    toHash.close();
-
-    calcMD5.calculate();
-
-    uint8_t buff[16];
-
-    calcMD5.getBytes(buff);
-
-    const String etag = "\"" + base64::encode(buff, 16, false) + "\"";
-
-    serveStaticETag(uri, fs, path, etag.c_str());
-
-  }
+// void ESP8266WebServerETagTemplate<ServerType>::serveStatic(const char* uri, FS& fs, const char * path) {
+//   serveStatic(uri, fs, path, "");
     
-}
+// }
 
 } // namespace

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
@@ -848,14 +848,19 @@ String ESP8266WebServerTemplate<ServerType>::responseCodeToString(const int code
 
 template<typename ServerType>
 void ESP8266WebServerETagTemplate<ServerType>::serveStatic(const char* uri, FS& fs, const char* path, const char* cache_header){
-  WST::_addRequestHandler(new StaticRequestETagHandler<ServerType>(fs, path, uri, cache_header));
+
+  bool is_file = false;
+
+  if (fs.exists(path)) {
+    File file = fs.open(path, "r");
+    is_file = file && file.isFile();
+    file.close();
+  }
+
+  if(is_file)
+    WST::_addRequestHandler(new StaticFileRequestHandler<ServerType>(fs, path, uri, cache_header));
+  else
+    WST::_addRequestHandler(new StaticDirectoryRequestHandler<ServerType>(fs, path, uri, cache_header));  
 }
-
-
-// template<typename ServerType>
-// void ESP8266WebServerETagTemplate<ServerType>::serveStatic(const char* uri, FS& fs, const char * path) {
-//   serveStatic(uri, fs, path, "");
-    
-// }
 
 } // namespace

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer-impl.h
@@ -255,7 +255,18 @@ void ESP8266WebServerTemplate<ServerType>::_addRequestHandler(RequestHandlerType
 
 template <typename ServerType>
 void ESP8266WebServerTemplate<ServerType>::serveStatic(const char* uri, FS& fs, const char* path, const char* cache_header) {
-    _addRequestHandler(new StaticRequestHandler<ServerType>(fs, path, uri, cache_header));
+  bool is_file = false;
+
+  if (fs.exists(path)) {
+    File file = fs.open(path, "r");
+    is_file = file && file.isFile();
+    file.close();
+  }
+
+  if(is_file)
+    _addRequestHandler(new StaticFileRequestHandler<ServerType>(fs, path, uri, cache_header));
+  else
+    _addRequestHandler(new StaticDirectoryRequestHandler<ServerType>(fs, path, uri, cache_header));  
 }
 
 template <typename ServerType>
@@ -607,29 +618,18 @@ const String& ESP8266WebServerTemplate<ServerType>::header(const String& name) c
   return emptyString;
 }
 
-template <typename ServerType>
-void ESP8266WebServerTemplate<ServerType>::collectHeaders(const char* headerKeys[], const size_t headerKeysCount) {
-  _headerKeysCount = headerKeysCount + 1;
-  if (_currentHeaders)
-     delete[]_currentHeaders;
-  _currentHeaders = new RequestArgument[_headerKeysCount];
-  _currentHeaders[0].key = FPSTR(AUTHORIZATION_HEADER);
-  for (int i = 1; i < _headerKeysCount; i++){
-    _currentHeaders[i].key = headerKeys[i-1];
-  }
-}
 
 template<typename ServerType>
-void ESP8266WebServerETagTemplate<ServerType>::collectHeaders(const char* headerKeys[], const size_t headerKeysCount) {
-  WST::_headerKeysCount = headerKeysCount + 2;
-  if (WST::_currentHeaders){
-    delete[] WST::_currentHeaders;
+void ESP8266WebServerTemplate<ServerType>::collectHeaders(const char* headerKeys[], const size_t headerKeysCount) {
+  _headerKeysCount = headerKeysCount + 2;
+  if (_currentHeaders){
+    delete[] _currentHeaders;
   }
-  WST::_currentHeaders = new typename WST::RequestArgument[WST::_headerKeysCount];
-  WST::_currentHeaders[0].key = FPSTR(AUTHORIZATION_HEADER);
-  WST::_currentHeaders[1].key = FPSTR(ETAG_HEADER);
-  for (int i = 2; i < WST::_headerKeysCount; i++){
-      WST::_currentHeaders[i].key = headerKeys[i-2];
+  _currentHeaders = new RequestArgument[_headerKeysCount];
+  _currentHeaders[0].key = FPSTR(AUTHORIZATION_HEADER);
+  _currentHeaders[1].key = FPSTR(ETAG_HEADER);
+  for (int i = 2; i < _headerKeysCount; i++){
+      _currentHeaders[i].key = headerKeys[i-2];
   }
 }
 
@@ -845,17 +845,5 @@ String ESP8266WebServerTemplate<ServerType>::responseCodeToString(const int code
     }
     return String(r);
 }
-
-template<typename ServerType>
-void ESP8266WebServerETagTemplate<ServerType>::serveStatic(const char* uri, FS& fs, const char* path, const char* cache_header){
-  WST::_addRequestHandler(new StaticRequestETagHandler<ServerType>(fs, path, uri, cache_header));
-}
-
-
-// template<typename ServerType>
-// void ESP8266WebServerETagTemplate<ServerType>::serveStatic(const char* uri, FS& fs, const char * path) {
-//   serveStatic(uri, fs, path, "");
-    
-// }
 
 } // namespace

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.h
@@ -300,21 +300,6 @@ protected:
   HookFunction     _hook;
 };
 
-
-template<typename ServerType>
-class ESP8266WebServerETagTemplate : public ESP8266WebServerTemplate<ServerType>
-{
-  using WST = ESP8266WebServerTemplate<ServerType>;
-
-  // using WST::WST;
-
-  using ESP8266WebServerTemplate<ServerType>::ESP8266WebServerTemplate;
-
-  public:
-  void collectHeaders(const char* headerKeys[], const size_t headerKeysCount);
-  void serveStatic(const char* uri, fs::FS& fs, const char* path, const char* cache_header = NULL );
-};
-
 } // namespace
 
 #include "ESP8266WebServer-impl.h"
@@ -322,7 +307,5 @@ class ESP8266WebServerETagTemplate : public ESP8266WebServerTemplate<ServerType>
 
 using ESP8266WebServer = esp8266webserver::ESP8266WebServerTemplate<WiFiServer>;
 using RequestHandler = esp8266webserver::RequestHandler<WiFiServer>;
-
-using  ESP8266WebServerETag = esp8266webserver::ESP8266WebServerETagTemplate<WiFiServer>;
 
 #endif //ESP8266WEBSERVER_H

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.h
@@ -304,16 +304,15 @@ protected:
 template<typename ServerType>
 class ESP8266WebServerETagTemplate : public ESP8266WebServerTemplate<ServerType>
 {
-  // using WST = ESP8266WebServerTemplate<ServerType>;
+  using WST = ESP8266WebServerTemplate<ServerType>;
 
   // using WST::WST;
 
   using ESP8266WebServerTemplate<ServerType>::ESP8266WebServerTemplate;
-  
+
   public:
   void collectHeaders(const char* headerKeys[], const size_t headerKeysCount);
-  void serveStaticETag(const char* uri, FS& fs, const char* path, const char* cache_header);
-  void serveStaticETag(const char* uri, FS& fs, const char* path);
+  void serveStatic(const char* uri, fs::FS& fs, const char* path, const char* cache_header = NULL );
 };
 
 } // namespace

--- a/libraries/ESP8266WebServer/src/ESP8266WebServer.h
+++ b/libraries/ESP8266WebServer/src/ESP8266WebServer.h
@@ -304,10 +304,12 @@ protected:
 template<typename ServerType>
 class ESP8266WebServerETagTemplate : public ESP8266WebServerTemplate<ServerType>
 {
-  using WST = ESP8266WebServerTemplate<ServerType>;
+  // using WST = ESP8266WebServerTemplate<ServerType>;
 
-  using WST::WST;
+  // using WST::WST;
 
+  using ESP8266WebServerTemplate<ServerType>::ESP8266WebServerTemplate;
+  
   public:
   void collectHeaders(const char* headerKeys[], const size_t headerKeysCount);
   void serveStaticETag(const char* uri, FS& fs, const char* path, const char* cache_header);

--- a/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
+++ b/libraries/ESP8266WebServer/src/detail/RequestHandlersImpl.h
@@ -72,83 +72,11 @@ public:
     , _path(path)
     , _cache_header(cache_header)
     {
-        if (fs.exists(path)) {
-            File file = fs.open(path, "r");
-            _isFile = file && file.isFile();
-            file.close();
-        }
-        else {
-            _isFile = false;
-        }
-
         DEBUGV("StaticRequestHandler: path=%s uri=%s isFile=%d, cache_header=%s\r\n", path, uri, _isFile, cache_header == __null ? "" : cache_header);
-        _baseUriLength = _uri.length();
     }
 
-    bool canHandle(HTTPMethod requestMethod, const String& requestUri) override  {
-        if ((requestMethod != HTTP_GET) && (requestMethod != HTTP_HEAD))
-            return false;
-
-        if ((_isFile && requestUri != _uri) || !requestUri.startsWith(_uri))
-            return false;
-
-        return true;
-    }
-
-    bool handle(WebServerType& server, HTTPMethod requestMethod, const String& requestUri) override {
-
-        if (!canHandle(requestMethod, requestUri))
-            return false;
-
-        DEBUGV("StaticRequestHandler::handle: request=%s _uri=%s\r\n", requestUri.c_str(), _uri.c_str());
-
-        String path;
-        path.reserve(_path.length() + requestUri.length() + 32);
-        path = _path;
-
-        if (!_isFile) {
-
-            // Append whatever follows this URI in request to get the file path.
-            path += requestUri.substring(_baseUriLength);
-
-            // Base URI doesn't point to a file.
-            // If a directory is requested, look for index file.
-            if (path.endsWith("/"))
-                path += F("index.htm");
-
-            // If neither <blah> nor <blah>.gz exist, and <blah> is a file.htm, try it with file.html instead
-            // For the normal case this will give a search order of index.htm, index.htm.gz, index.html, index.html.gz
-            if (!_fs.exists(path) && !_fs.exists(path + ".gz") && path.endsWith(".htm")) {
-                path += 'l';
-            }
-        }
-        DEBUGV("StaticRequestHandler::handle: path=%s, isFile=%d\r\n", path.c_str(), _isFile);
-
-        String contentType = mime::getContentType(path);
-
-        using namespace mime;
-        // look for gz file, only if the original specified path is not a gz.  So part only works to send gzip via content encoding when a non compressed is asked for
-        // if you point the the path to gzip you will serve the gzip as content type "application/x-gzip", not text or javascript etc...
-        if (!path.endsWith(FPSTR(mimeTable[gz].endsWith)) && !_fs.exists(path))  {
-            String pathWithGz = path + FPSTR(mimeTable[gz].endsWith);
-            if(_fs.exists(pathWithGz))
-                path += FPSTR(mimeTable[gz].endsWith);
-        }
-
-        File f = _fs.open(path, "r");
-        if (!f)
-            return false;
-
-        if (!f.isFile()) {
-            f.close();
-            return false;
-        }
-
-        if (_cache_header.length() != 0)
-            server.sendHeader("Cache-Control", _cache_header);
-
-        server.streamFile(f, contentType, requestMethod);
-        return true;
+    bool validMethod(HTTPMethod requestMethod){
+        return (requestMethod == HTTP_GET) || (requestMethod == HTTP_HEAD);
     }
 
     /* Deprecated version. Please use mime::getContentType instead */
@@ -161,49 +89,113 @@ protected:
     String _uri;
     String _path;
     String _cache_header;
-    bool _isFile;
+};
+
+
+template<typename ServerType>
+class StaticDirectoryRequestHandler : public StaticRequestHandler<ServerType> {
+
+    using SRH = StaticRequestHandler<ServerType>;
+    using WebServerType = ESP8266WebServerTemplate<ServerType>;
+
+public:
+    StaticDirectoryRequestHandler(FS& fs, const char* path, const char* uri, const char* cache_header)
+        :
+    SRH(fs, path, uri, cache_header),
+    _baseUriLength{SRH::_uri.length()}
+    {}
+
+    bool canHandle(HTTPMethod requestMethod, const String& requestUri) override {
+        return SRH::validMethod(requestMethod) && requestUri.startsWith(SRH::_uri);
+    }
+
+    bool handle(WebServerType& server, HTTPMethod requestMethod, const String& requestUri) override {
+
+        if (!canHandle(requestMethod, requestUri))
+            return false;
+
+        DEBUGV("DirectoryRequestHandler::handle: request=%s _uri=%s\r\n", requestUri.c_str(), SRH::_uri.c_str());
+
+        String path;
+        path.reserve(SRH::_path.length() + requestUri.length() + 32);
+        path = SRH::_path;
+
+        // Append whatever follows this URI in request to get the file path.
+        path += requestUri.substring(_baseUriLength);
+
+        // Base URI doesn't point to a file.
+        // If a directory is requested, look for index file.
+        if (path.endsWith("/"))
+            path += F("index.htm");
+
+        // If neither <blah> nor <blah>.gz exist, and <blah> is a file.htm, try it with file.html instead
+        // For the normal case this will give a search order of index.htm, index.htm.gz, index.html, index.html.gz
+        if (!SRH::_fs.exists(path) && !SRH::_fs.exists(path + ".gz") && path.endsWith(".htm")) {
+            path += 'l';
+        }
+
+        DEBUGV("DirectoryRequestHandler::handle: path=%s\r\n", path.c_str());
+
+        String contentType = mime::getContentType(path);
+
+        using namespace mime;
+        // look for gz file, only if the original specified path is not a gz.  So part only works to send gzip via content encoding when a non compressed is asked for
+        // if you point the the path to gzip you will serve the gzip as content type "application/x-gzip", not text or javascript etc...
+        if (!path.endsWith(FPSTR(mimeTable[gz].endsWith)) && !SRH::_fs.exists(path))  {
+            String pathWithGz = path + FPSTR(mimeTable[gz].endsWith);
+            if(SRH::_fs.exists(pathWithGz))
+                path += FPSTR(mimeTable[gz].endsWith);
+        }
+
+        File f = SRH::_fs.open(path, "r");
+        if (!f)
+            return false;
+
+        if (!f.isFile()) {
+            f.close();
+            return false;
+        }
+
+        if (SRH::_cache_header.length() != 0)
+            server.sendHeader("Cache-Control", SRH::_cache_header);
+
+        server.streamFile(f, contentType, requestMethod);
+        return true;
+    }
+
+protected:
     size_t _baseUriLength;
 };
 
 template<typename ServerType>
-class StaticRequestETagHandler
+class StaticFileRequestHandler
     :
 public StaticRequestHandler<ServerType> {
 
     using SRH = StaticRequestHandler<ServerType>;
-
     using WebServerType = ESP8266WebServerTemplate<ServerType>;
 
-    protected:
-    uint8_t _ETag_md5[16];
-   
-    void computeMD5(File toHash){
-        MD5Builder calcMD5;
-        calcMD5.begin();
-        calcMD5.addStream(toHash, toHash.size());
-        calcMD5.calculate();
-        calcMD5.getBytes(_ETag_md5);
-    }
-
-
-    public:
-    StaticRequestETagHandler(FS& fs, const char* path, const char* uri, const char* cache_header)
+public:
+    StaticFileRequestHandler(FS& fs, const char* path, const char* uri, const char* cache_header)
         :
     StaticRequestHandler<ServerType>{fs, path, uri, cache_header}
     {
-        File f = fs.open(path, "r");
-        if(f){
-            if(f.isFile())
-                computeMD5(f);
-            f.close();
-        }
+        File f = SRH::_fs.open(path, "r");
+        MD5Builder calcMD5;
+        calcMD5.begin();
+        calcMD5.addStream(f, f.size());
+        calcMD5.calculate();
+        calcMD5.getBytes(_ETag_md5);
+        f.close();
+    }
 
+    bool canHandle(HTTPMethod requestMethod, const String& requestUri) override  {
+        return SRH::validMethod(requestMethod) && requestUri == SRH::_uri;
     }
 
     bool handle(WebServerType& server, HTTPMethod requestMethod, const String & requestUri) override {
-        if (!SRH::canHandle(requestMethod, requestUri)){
+        if (!canHandle(requestMethod, requestUri))
             return false;
-        }
 
         const String etag = "\"" + base64::encode(_ETag_md5, 16, false) + "\"";
 
@@ -227,49 +219,12 @@ public StaticRequestHandler<ServerType> {
 
         server.sendHeader("ETag", etag);
 
-
-        server.streamFile(f, SRH::getContentType(SRH::_path), requestMethod);
+        server.streamFile(f, mime::getContentType(SRH::_path), requestMethod);
         return true;
-
     }
 
-    // bool handle(WebServerType& server, HTTPMethod requestMethod, const String & requestUri) override {
-    //     if (!SRH::canHandle(requestMethod, requestUri)){
-    //         return false;
-    //     }
-
-    //     File f = SRH::_fs.open(SRH::_path, "r");
-
-    //     if (!f)
-    //         return false;
-
-    //     if (!f.isFile()) {
-    //         f.close();
-    //         return false;
-    //     }
-
-    //     if(last_edit == f.getLastWrite()){
-    //         //update chache
-    //     }
-
-    //     const String etag = "\"" + base64::encode(buff, 16, false) + "\"";
-
-    //     if(server.header("If-None-Match") == etag){
-    //         server.send(304);
-    //         return true;
-    //     }
-
-    //     if (_cache_header.length() != 0)
-    //         server.sendHeader("Cache-Control", SRH::_cache_header);
-
-    //     server.sendHeader("ETag", etag);
-
-
-    //     server.streamFile(f, SRH::getContentType(SRH::_path), requestMethod);
-    //     return true;
-
-    // }
-        
+protected:
+    uint8_t _ETag_md5[16];       
 };
 
 } // namespace


### PR DESCRIPTION
Enable ETag support by splitting and specialising `StaticRequestHandler` for the `Directory` and `File` case
This also minimally reduce memory footprint